### PR TITLE
Add CLI tests and fix draft phase

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,34 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from water_barons.cli import CLI
+from water_barons.game_logic import GameLogic
+
+class TestCLI(unittest.TestCase):
+    @patch('builtins.input', side_effect=['1', 'Alice'])
+    def test_start_invokes_game_loop(self, mock_in):
+        cli = CLI()
+        with patch.object(cli, '_game_loop') as mock_loop:
+            cli.start()
+            mock_loop.assert_called_once()
+            self.assertIsInstance(cli.game_logic, GameLogic)
+
+    @patch('builtins.input', side_effect=['0', '5', '2'])
+    def test_get_num_players_validation(self, mock_in):
+        cli = CLI()
+        num = cli._get_num_players()
+        self.assertEqual(num, 2)
+
+    @patch('builtins.print')
+    @patch('builtins.input', side_effect=['1', '1'])
+    def test_cli_action_build_facility(self, mock_in, mock_print):
+        cli = CLI()
+        cli.game_logic = GameLogic(1, ['Alice'])
+        player = cli.game_logic.game_state.players[0]
+        cli.game_logic.action_build_facility = MagicMock(return_value=True)
+        initial_len = len(cli.game_logic.game_state.facility_deck)
+        cli._cli_action_build_facility(player)
+        cli.game_logic.action_build_facility.assert_called_once()
+        self.assertEqual(len(cli.game_logic.game_state.facility_deck), initial_len - 1)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/water_barons/game_logic.py
+++ b/water_barons/game_logic.py
@@ -186,6 +186,20 @@ class GameLogic:
         gs.whim_draft_current_picker_idx_in_order += 1
         return True
 
+    def whim_draft_phase(self, get_player_draft_choice_cb):
+        """Runs the interactive Whim draft using the provided callback."""
+        next_pick = self.initiate_whim_draft()
+        while next_pick:
+            player, options, pick_num = next_pick
+            try:
+                choice = get_player_draft_choice_cb(player, options, pick_num)
+            except Exception:
+                choice = -1
+            if choice is None:
+                choice = -1
+            self.process_whim_draft_pick(player, choice)
+            next_pick = self.request_next_whim_draft_pick()
+
 
     def ops_phase(self, get_player_action_choice_cb):
         """


### PR DESCRIPTION
## Summary
- implement missing `whim_draft_phase` in `GameLogic`
- create new `tests/test_cli.py` with unit tests for the CLI
- ensure CLI draft phase now works

## Testing
- `python -m pip install -r requirements.txt`
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_686c196674e0832b9431000958d291c5