### PR TITLE
Add GameState serialization

### DIFF
--- a/tests/test_game_state.py
+++ b/tests/test_game_state.py
@@ -1,4 +1,6 @@
 import unittest
+import tempfile
+import os
 from water_barons.game_state import GameState, ImpactTrack
 from water_barons.game_entities import TrackColor, Player, GlobalEventCard
 from water_barons.cards import get_all_global_event_tiles # To get some sample events
@@ -100,6 +102,18 @@ class TestGameState(unittest.TestCase):
         self.assertEqual(self.gs.impact_tracks[TrackColor.GREY].thresholds[6], "CO2_Level_6_Effect")
         self.assertIn(5, self.gs.impact_tracks[TrackColor.BLUE].thresholds) # DEP Level 5
         self.assertEqual(self.gs.impact_tracks[TrackColor.BLUE].thresholds[5], "DEP_Level_5_Effect")
+
+    def test_save_and_load(self):
+        self.gs.round_number = 3
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            path = tmp.name
+        try:
+            self.gs.save_to_file(path)
+            loaded = GameState.load_from_file(path)
+            self.assertEqual(loaded.round_number, 3)
+            self.assertEqual(len(loaded.players), 2)
+        finally:
+            os.remove(path)
 
 
 if __name__ == '__main__':

--- a/water_barons/game_state.py
+++ b/water_barons/game_state.py
@@ -1,4 +1,5 @@
 from typing import List, Dict, Optional
+import pickle
 from water_barons.game_entities import TrackColor, Player, Card, WhimCard, GlobalEventCard, DemandSegment, FacilityCard, DistributionCard, UpgradeCard
 
 class ImpactTrack:
@@ -160,6 +161,17 @@ class GameState:
     def __repr__(self):
         return (f"GameState(Round: {self.round_number}, Player: {self.get_current_player().name}, "
                 f"Tracks: {[str(t) for t in self.impact_tracks.values()]})")
+
+    def save_to_file(self, filepath: str) -> None:
+        """Serialize the game state to a file using pickle."""
+        with open(filepath, 'wb') as f:
+            pickle.dump(self, f)
+
+    @staticmethod
+    def load_from_file(filepath: str) -> 'GameState':
+        """Load a game state previously saved with `save_to_file`."""
+        with open(filepath, 'rb') as f:
+            return pickle.load(f)
 
 if __name__ == '__main__':
     gs = GameState(num_players=2, player_names=["Alice", "Bob"])


### PR DESCRIPTION
## Summary
- enable saving/loading GameState with pickle
- test saving and loading a GameState

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c241043dc832b942b3954cd844954