### PR TITLE
Externalize card and action data

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ This is a Python-based application. Ensure you have Python 3.8+ installed.
 
 4.  **Follow the on-screen prompts to start a new game, enter player names, and play.**
 
+5.  **Customize Card Data (Optional):**
+    All facilities, upgrades, whims, and player actions are defined in
+    `water_barons/game_content.toml`. Edit this file to tweak values for a
+    print‑and‑play version of the game.  Set the environment variable
+    `WATER_BARONS_DATA_FILE` to load card data from a different path.
+
 ## Game Overview (Simplified for CLI)
 
 The game proceeds in rounds, each consisting of several phases:

--- a/tests/test_card_loading.py
+++ b/tests/test_card_loading.py
@@ -1,0 +1,35 @@
+import os
+import importlib
+import textwrap
+from tempfile import NamedTemporaryFile
+
+import pytest
+
+def test_cards_load_from_env_path(monkeypatch):
+    sample = textwrap.dedent("""
+    [[facilities]]
+    name = "Temp Facility"
+    cost = 1
+    base_output = 1
+    copies = 1
+    impact_profile = {GREY = 1}
+
+    [[actions]]
+    name = "Dummy Action"
+    method = "action_dummy"
+    description = "dummy"
+    """)
+    with NamedTemporaryFile('w+', delete=False) as tmp:
+        tmp.write(sample)
+        tmp_path = tmp.name
+    monkeypatch.setenv('WATER_BARONS_DATA_FILE', tmp_path)
+    import water_barons.cards as cards
+    importlib.reload(cards)
+    try:
+        facilities = cards.get_all_facility_cards()
+        assert any(f.name == "Temp Facility" for f in facilities)
+        assert cards.ACTIONS_DATA and cards.ACTIONS_DATA[0]['name'] == "Dummy Action"
+    finally:
+        monkeypatch.delenv('WATER_BARONS_DATA_FILE', raising=False)
+        os.remove(tmp_path)
+        importlib.reload(cards)

--- a/water_barons/cards.py
+++ b/water_barons/cards.py
@@ -1,306 +1,101 @@
+import os
+from pathlib import Path
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # pragma: no cover - fallback for older Python
+    import tomli as tomllib
 from water_barons.game_entities import (
     FacilityCard, DistributionCard, UpgradeCard, WhimCard, GlobalEventCard,
     TrackColor
 )
 
-# --- Facility Cards ---
-FACILITIES_DATA = [
-    {
-        "name": "Glacial Tap", "cost": 5, "base_output": 3,
-        "impact_profile": {TrackColor.GREY: 1, TrackColor.PINK: 1},
-        "tags": ["ARCTIC", "LIMITED 2"], "description": "Taps into ancient glaciers."
-    },
-    {
-        "name": "Greywater Loop", "cost": 3, "base_output": 2,
-        "impact_profile": {TrackColor.GREEN: 1}, # Original: +1 TOX, -1 μP. -1 uP needs special handling.
-        "tags": ["RECYCLING"], "description": "Recycles wastewater. Reduces Microplastics."
-        # Note: The "-1 μP" is an effect that needs to be modeled, perhaps as a negative impact or a special ability.
-        # For now, impact_profile only handles positive additions. We can add a 'mitigation_profile' later.
-    },
-    {
-        "name": "Aquifer Well", "cost": 4, "base_output": 4,
-        "impact_profile": {TrackColor.BLUE: 2},
-        "tags": ["GROUNDWATER"], "description": "Standard well drawing from aquifers."
-    },
-    {
-        "name": "Desalination Plant", "cost": 7, "base_output": 5,
-        "impact_profile": {TrackColor.GREY: 2, TrackColor.GREEN: 1}, # High energy, some brine/chem discharge
-        "tags": ["COASTAL", "HIGH_ENERGY"], "description": "Converts seawater to freshwater."
-    },
-    {
-        "name": "Cloud Harvester", "cost": 6, "base_output": 2,
-        "impact_profile": {TrackColor.GREY: 1}, # Energy for atmospheric condensation
-        "tags": ["ATMOSPHERIC"], "description": "Collects water vapor from the air."
-    },
-    {
-        "name": "Fog Net Array", "cost": 3, "base_output": 1,
-        "impact_profile": {}, # Minimal direct impact
-        "tags": ["PASSIVE", "COASTAL"], "description": "Passively collects water from fog."
-    }
-]
+_DATA_FILE = Path(
+    os.getenv("WATER_BARONS_DATA_FILE", Path(__file__).with_name("game_content.toml"))
+)
 
-# --- Distribution Cards ---
-DISTRIBUTION_DATA = [
-    {
-        "name": "Plastic Bottles", "cost": 1,
-        "description": "Cheap, adds +1 μP per 2 cubes sold.",
-        "impact_modifier": {"μP_per_cubes_sold": {"impact": TrackColor.PINK, "amount": 1, "per_cubes": 2}}
-    },
-    {
-        "name": "Drone Drops", "cost": 3,
-        "description": "Fancy, +1 CO₂e per cube, draws extra Whim next round.",
-        "impact_modifier": {"CO2e_per_cube_sold": {"impact": TrackColor.GREY, "amount": 1, "per_cubes": 1}},
-        "special_effect": "draw_extra_whim_next_round"
-    },
-    {
-        "name": "Smart-Pipe Network", "cost": 5,
-        "description": "Efficient, high upfront cost, low ongoing impact.",
-        "impact_modifier": {} # Minimal operational impact
-    },
-    {
-        "name": "Aluminum Cans", "cost": 2,
-        "description": "Recyclable alternative to plastic, +1 CO₂e per 3 cubes sold (production energy).",
-        "impact_modifier": {"CO2e_per_cubes_sold": {"impact": TrackColor.GREY, "amount": 1, "per_cubes": 3}}
-    }
-]
+with open(_DATA_FILE, "rb") as f:
+    _RAW_DATA = tomllib.load(f)
 
-# --- Upgrade/Mitigation Cards ---
-UPGRADES_DATA = [
-    {
-        "name": "Microplastic Filter", "cost": 4, "description": "Facility upgrade. Reduces μP per Flow.",
-        "effect_description": "Apply_to_facility: reduce_impact_per_flow(TrackColor.PINK, 1)",
-        "type": "FACILITY_UPGRADE"
-    },
-    {
-        "name": "Bioplastic Seal", "cost": 3, "description": "Route upgrade, remove 1 μP after selling with this route.",
-        "effect_description": "Apply_to_route: on_sell_remove_impact(TrackColor.PINK, 1)", # This effect needs specific handling during sales impact calculation
-        "type": "ROUTE_UPGRADE"
-    },
-    {
-        "name": "Algae Carbon Sink", "cost": 5, "description": "Facility tag. At Cleanup, move 1 CO₂e cube from track to supply.",
-        "effect_description": "Passive_facility_effect: at_cleanup_reduce_global_impact(TrackColor.GREY, 1)", # Needs a new "cleanup" step for these effects
-        "type": "FACILITY_TAG"
-    },
-    {
-        "name": "Aquifer Recharge Tech", "cost": 6, "description": "R&D Passive. Reduce DEP impact from all your Wells by 1.",
-        "effect_description": "Global_player_passive: reduce_facility_impact_type('Well', TrackColor.BLUE, 1)", # Parsed in _get_passive_player_impact_reduction
-        "type": "R&D"
-    },
-    {
-        "name": "Eco-Solar Upgrade", "cost": 4, "description": "Facility Upgrade. Reduces CO2e impact from target facility by 1.",
-        "effect_description": "Apply_to_facility: reduce_impact_per_flow(TrackColor.GREY, 1)",
-        "type": "FACILITY_UPGRADE"
-    },
-    {
-        "name": "Nano-Resin Cleaners", "cost": 5, "description": "Facility Upgrade. Reduces TOX impact from target facility by 1.",
-        "effect_description": "Apply_to_facility: reduce_impact_per_flow(TrackColor.GREEN, 1)",
-        "type": "FACILITY_UPGRADE"
-    }
-]
+FACILITIES_DATA = _RAW_DATA.get("facilities", [])
+DISTRIBUTION_DATA = _RAW_DATA.get("distributions", [])
+UPGRADES_DATA = _RAW_DATA.get("upgrades", [])
+WHIMS_DATA = _RAW_DATA.get("whims", [])
+GLOBAL_EVENTS_DATA = _RAW_DATA.get("global_events", [])
+ACTIONS_DATA = _RAW_DATA.get("actions", [])
 
-# --- Whim Cards ---
-WHIMS_DATA = [
-    {
-        "name": "Glitterwave Fashion", "trigger_condition": "μP < 5",
-        "pre_round_effect": "DemandSegment:Connoisseurs:current_demand:+2",
-        "demand_shift": {}, # Incorporated into pre-round for this structure
-        "post_round_fallout": "GlobalImpact:PINK:+2"
-    },
-    {
-        "name": "Doomscroll Detox", "trigger_condition": "CO₂e >= 6",
-        "pre_round_effect": "DemandSegment:Frugalists:current_price:+1", # Panic hoarding
-        "demand_shift": {},
-        "post_round_fallout": "GlobalImpact:GREY:-1" # Viral eco-challenge
-    },
-    {
-        "name": "Heatwave Hysteria", "trigger_condition": "CO₂e >= 7", # Different from Global Event trigger
-        "pre_round_effect": "AllSegments:current_demand:+1", # General thirst
-        "demand_shift": {},
-        "post_round_fallout": "GlobalImpact:GREY:+1" # AC units go brrr
-    },
-    {
-        "name": "Sustainable Sipping", "trigger_condition": "DEP < 4",
-        "pre_round_effect": "DemandSegment:Eco-Elites:current_price:+1", # Willing to pay more for sustainable
-        "demand_shift": {},
-        "post_round_fallout": "PlayerEffect:EcoEliteBuyers:GainReputation:1" # Reward players who sold to Eco-Elites
-    }
-]
-
-# --- Global Event Tiles ---
-GLOBAL_EVENTS_DATA = [
-    {
-        "name": "Aquifer Collapse", "trigger_track": TrackColor.BLUE, "trigger_threshold": 8, # DEP Level 8+
-        "effect_description": "All 'Well' type facilities output halved until Depletion <= 6. New Wells cannot be built."
-    },
-    {
-        "name": "Heatwave Frenzy", "trigger_track": TrackColor.GREY, "trigger_threshold": 9, # CO2e Level 9+
-        "effect_description": "Double demand across all segments. All facilities Flow –1 (overheat)."
-    },
-    {
-        "name": "Microplastic Revelation", "trigger_track": TrackColor.PINK, "trigger_threshold": 8, # μP Level 8+
-        "effect_description": "All 'Plastic Bottles' routes instantly add +3 μP then flip face-down (cannot be used)."
-    },
-    {
-        "name": "Mass Recall", "trigger_track": TrackColor.GREEN, "trigger_threshold": 10, # TOX Level 10
-        "effect_description": "All unsold Water cubes are immediately discarded. No sales this round from tainted supply."
-    },
-    # Adding a few more as per the component list (8 total mentioned)
-    {
-        "name": "Energy Crisis", "trigger_track": TrackColor.GREY, "trigger_threshold": 7,
-        "effect_description": "Cost of 'Flow' action for energy-heavy facilities (Desal, Drone) increases by 1 CredCoin."
-    },
-    {
-        "name": "Plastic Blight", "trigger_track": TrackColor.PINK, "trigger_threshold": 6,
-        "effect_description": "Facilities with 'Plastic' in their components (hypothetical) or Plastic Bottle routes suffer -1 output/efficiency."
-    },
-    {
-        "name": "Dustbowl Proclamation", "trigger_track": TrackColor.BLUE, "trigger_threshold": 6, # Earlier than full collapse
-        "effect_description": "Cost to build new 'Well' or 'River Diversion' (hypothetical) facilities increases by 2 CredCoin."
-    },
-    {
-        "name": "Toxic Algae Bloom", "trigger_track": TrackColor.GREEN, "trigger_threshold": 7, # Earlier than mass recall
-        "effect_description": "Water from 'Coastal' tagged facilities costs +1 CredCoin for players to produce (extra filtering)."
-    }
-]
-
+def _convert_profile(profile_dict: dict) -> dict:
+    return {TrackColor[key]: value for key, value in profile_dict.items()}
 
 def get_all_facility_cards() -> list[FacilityCard]:
-    cards = []
+    cards: list[FacilityCard] = []
     for data in FACILITIES_DATA:
-        # The original design doc says "6 distinct types x3 each" = 18 cards
-        # For now, just creating one of each for easier testing of variety
-        # Duplication can be handled when building the actual decks in GameState
-        cards.append(FacilityCard(name=data["name"], cost=data["cost"], base_output=data["base_output"],
-                                  impact_profile=data["impact_profile"], tags=data.get("tags", [])))
-    return cards * 3 # Multiply to get 18 cards as per spec
+        impact_profile = _convert_profile(data.get("impact_profile", {}))
+        card = FacilityCard(
+            name=data["name"],
+            cost=data["cost"],
+            base_output=data["base_output"],
+            impact_profile=impact_profile,
+            tags=data.get("tags", []),
+        )
+        cards.extend([card] * int(data.get("copies", 1)))
+    return cards
 
 def get_all_distribution_cards() -> list[DistributionCard]:
-    cards = []
+    cards: list[DistributionCard] = []
     for data in DISTRIBUTION_DATA:
-        cards.append(DistributionCard(name=data["name"], cost=data["cost"], description=data["description"],
-                                      impact_modifier=data.get("impact_modifier"), special_effect=data.get("special_effect")))
-    return cards * 3 # 4 types x 3 each = 12 cards
+        impact_mod = {}
+        for key, details in data.get("impact_modifier", {}).items():
+            mod = details.copy()
+            if "impact" in mod:
+                mod["impact"] = TrackColor[mod["impact"]]
+            impact_mod[key] = mod
+        card = DistributionCard(
+            name=data["name"],
+            cost=data["cost"],
+            description=data["description"],
+            impact_modifier=impact_mod,
+            special_effect=data.get("special_effect"),
+        )
+        cards.extend([card] * int(data.get("copies", 1)))
+    return cards
 
 def get_all_upgrade_cards() -> list[UpgradeCard]:
-    cards = []
+    cards: list[UpgradeCard] = []
     for data in UPGRADES_DATA:
-        cards.append(UpgradeCard(name=data["name"], cost=data["cost"], description=data["description"],
-                                 effect_description=data["effect_description"], type=data.get("type", "GENERIC_UPGRADE")))
-    # Assuming 8 unique types as per doc, so 8 * 3 = 24. Current data has 6.
-    # To match 24 cards:
-    num_unique_upgrades = len(UPGRADES_DATA)
-    if num_unique_upgrades > 0:
-        # Multiply each unique card to simulate having 3 copies of each of the 8 distinct types.
-        # If we have 6 unique, we make 4 copies of each to get 24.
-        # Better: ensure UPGRADES_DATA has 8 unique items, then multiply by 3.
-        # For now, if we have 6 unique, we'll make 24 by doing 6 * 4.
-        copies_per_unique = (24 // num_unique_upgrades) if num_unique_upgrades > 0 else 1
-        full_set = []
-        for card_obj in cards: # cards list currently has one of each unique
-            full_set.extend([card_obj] * copies_per_unique) # This is not quite right if UPGRADES_DATA < 8
-                                                            # it should be card_obj * 3 if UPGRADES_DATA has 8 items.
-        # Correcting logic for "8 types x 3 each"
-        # The list 'cards' contains one of each unique type defined in UPGRADES_DATA.
-        # If we assume UPGRADES_DATA is the complete list of unique types (e.g. 8 types),
-        # then we just need 3 copies of each.
-        final_cards = []
-        for card_obj in cards: # 'cards' has one of each from UPGRADES_DATA
-            final_cards.extend([
-                UpgradeCard(name=card_obj.name, cost=card_obj.cost, description=card_obj.description,
-                            effect_description=card_obj.effect_description, type=card_obj.type)
-                for _ in range(3) # Create 3 distinct objects for each type
-            ])
-        return final_cards
-        # This ensures we have 3 actual objects for each of the unique types defined.
-        # If UPGRADES_DATA has 6 items, this results in 18 cards. If it had 8, it'd be 24.
-    return []
-
+        card = UpgradeCard(
+            name=data["name"],
+            cost=data["cost"],
+            description=data["description"],
+            effect_description=data["effect_description"],
+            type=data.get("type", "GENERIC_UPGRADE"),
+        )
+        cards.extend([card] * int(data.get("copies", 1)))
+    return cards
 
 def get_all_whim_cards() -> list[WhimCard]:
-    cards = []
+    cards: list[WhimCard] = []
     for data in WHIMS_DATA:
-        cards.append(WhimCard(name=data["name"], trigger_condition=data["trigger_condition"],
-                              pre_round_effect=data["pre_round_effect"], demand_shift=data["demand_shift"],
-                              post_round_fallout=data["post_round_fallout"]))
-    # 24 unique whims x 2 copies each = 48 cards
-    # Current unique whims: len(WHIMS_DATA). Need 24 unique.
-    # For now, we'll duplicate the existing ones to reach near 48 if needed, or assume more are defined.
-    num_unique_whims = len(WHIMS_DATA)
-    if num_unique_whims > 0 :
-        repeats_needed = 24 // num_unique_whims if num_unique_whims > 0 else 0
-        full_set = cards * repeats_needed
-        # if we need more to reach 24 unique types for x2 copies.
-        # This part needs actual unique card data.
-        # For now, just double what we have if aiming for "x2 copies each"
-        final_cards = []
-        for _ in range(2): # x2 copies each
-            final_cards.extend(cards)
-        # This will be more like WHIMS_DATA * (48 / len(WHIMS_DATA)) if all whims are unique
-        # For now, just 2 copies of the defined ones.
-        return final_cards * ( (24 // num_unique_whims if num_unique_whims > 0 else 1 ) * 2) # ensure we have enough cards for 48 total
-    return []
-
+        card = WhimCard(
+            name=data["name"],
+            trigger_condition=data["trigger_condition"],
+            pre_round_effect=data["pre_round_effect"],
+            demand_shift=data.get("demand_shift", {}),
+            post_round_fallout=data["post_round_fallout"],
+        )
+        cards.extend([card] * int(data.get("copies", 1)))
+    return cards
 
 def get_all_global_event_tiles() -> list[GlobalEventCard]:
-    return [GlobalEventCard(name=data["name"], trigger_track=data["trigger_track"],
-                            trigger_threshold=data["trigger_threshold"], effect_description=data["effect_description"])
-            for data in GLOBAL_EVENTS_DATA]
+    cards = []
+    for data in GLOBAL_EVENTS_DATA:
+        card = GlobalEventCard(
+            name=data["name"],
+            trigger_track=TrackColor[data["trigger_track"]],
+            trigger_threshold=data["trigger_threshold"],
+            effect_description=data["effect_description"],
+        )
+        cards.append(card)
+    return cards
 
-
-if __name__ == '__main__':
-    # Test card creation
-    facilities = get_all_facility_cards()
-    distributions = get_all_distribution_cards()
-    upgrades = get_all_upgrade_cards()
-    whims = get_all_whim_cards()
-    events = get_all_global_event_tiles()
-
-    print(f"Generated {len(facilities)} facility cards. First: {facilities[0] if facilities else 'None'}")
-    print(f"Generated {len(distributions)} distribution cards. First: {distributions[0] if distributions else 'None'}")
-    print(f"Generated {len(upgrades)} upgrade cards. First: {upgrades[0] if upgrades else 'None'}")
-    print(f"Generated {len(whims)} whim cards. First: {whims[0] if whims else 'None'}")
-    print(f"Generated {len(events)} global event tiles. First: {events[0] if events else 'None'}")
-
-    # Example of Greywater Loop's special property (conceptual)
-    greywater = next((f for f in facilities if f.name == "Greywater Loop"), None)
-    if greywater:
-        # This shows we need a way to model negative impact or mitigation directly on the card
-        print(f"\nNote on Greywater Loop: {greywater.description}")
-        # This could be handled by adding a `mitigation_profile: Dict[TrackColor, int]` to FacilityCard
-        # or special logic during the Flow action.
-        # For now, its impact_profile is just {TrackColor.GREEN: 1}.
-        # The "-1 μP" effect would be:
-        # player.impact_storage[TrackColor.PINK] -= 1 (or similar) when Flowing.
-
-    # Example of Drone Drops special effect
-    drones = next((d for d in distributions if d.name == "Drone Drops"), None)
-    if drones:
-        print(f"\nDrone Drops special effect: {drones.special_effect}")
-
-    # Example of Whim card effect parsing (conceptual)
-    glitter_whim = next((w for w in whims if w.name == "Glitterwave Fashion"), None)
-    if glitter_whim:
-        print(f"\nGlitterwave Fashion pre-round: {glitter_whim.pre_round_effect}")
-        # This string would need to be parsed by game logic, e.g.:
-        # parts = glitter_whim.pre_round_effect.split(':') -> ["DemandSegment", "Connoisseurs", "current_demand", "+2"]
-        # entity_type, entity_name, attribute_to_change, change_value = parts
-        # change_value_int = int(change_value)
-        # game_state.demand_segments[entity_name].current_demand += change_value_int
-        print(f"Glitterwave Fashion post-round: {glitter_whim.post_round_fallout}")
-        # parts = glitter_whim.post_round_fallout.split(':') -> ["GlobalImpact", "PINK", "+2"]
-        # game_state.add_global_impact(TrackColor.PINK, 2)
-
-    # Check total whim cards
-    # Target: 24 unique whims x 2 copies each = 48 cards
-    # Current unique whims defined: len(WHIMS_DATA)
-    # We need to either define more unique whims or adjust the multiplication
-    # The current get_all_whim_cards() makes 2 copies of the *defined* unique whims.
-    # If len(WHIMS_DATA) is 4, we get 4 * 2 = 8 cards.
-    # To get 48, if we have N unique whims, we need 48/N copies of each.
-    # Or, more simply, ensure WHIMS_DATA has 24 unique entries, then duplicate.
-    # The current logic `final_cards * ( (24 // num_unique_whims) * 2)` is a bit complex.
-    # Simpler: define 24 unique whims, then `return all_unique_whims * 2`.
-    # For now, `get_all_whim_cards` will produce `len(WHIMS_DATA) * 2 * (24 // len(WHIMS_DATA))` which aims for 48 if len(WHIMS_DATA) is a divisor of 24.
-    # Example: If 4 unique whims: 4 * 2 * (24 // 4) = 8 * 6 = 48 cards. This seems correct.
-    print(f"Number of unique whims defined: {len(WHIMS_DATA)}")
-    print(f"Total whim cards generated by get_all_whim_cards(): {len(get_all_whim_cards())}")
+# ACTIONS_DATA is exported for external use

--- a/water_barons/cli.py
+++ b/water_barons/cli.py
@@ -1,5 +1,6 @@
 from water_barons.game_logic import GameLogic
 from water_barons.game_entities import FacilityCard, DistributionCard, UpgradeCard, WhimCard
+from water_barons.cards import ACTIONS_DATA
 
 class CLI:
     """Command Line Interface for playing Water Barons."""
@@ -126,48 +127,46 @@ class CLI:
         self._display_player_dashboard(player)
         print(f"\n{player.name}, choose Action {action_num} of 2:")
         print("Available actions:")
-        print("1. Sink/Source (Build Facility)")
-        print("2. Flow (Produce Water)")
-        print("3. Route (Build Distribution)")
-        print("4. Tweak (Add Upgrade/Mitigation)")
-        print("5. Speculate (Buy/Sell Futures)")
-        print("6. Spin (Marketing - Not Implemented Yet)")
-        print("7. Pass Action")
-        print("8. View Full Game State")
+        for idx, action in enumerate(ACTIONS_DATA, start=1):
+            desc = action.get("description", "")
+            if desc:
+                print(f"{idx}. {action['name']} - {desc}")
+            else:
+                print(f"{idx}. {action['name']}")
+        pass_idx = len(ACTIONS_DATA) + 1
+        view_idx = pass_idx + 1
+        print(f"{pass_idx}. Pass Action")
+        print(f"{view_idx}. View Full Game State")
 
         while True:
             try:
-                choice = input("Enter action number (1-8): ").strip()
-                if choice == '1':
-                    self._cli_action_build_facility(player)
-                    break
-                elif choice == '2':
-                    self._cli_action_produce_water(player)
-                    break
-                elif choice == '3':
-                    self._cli_action_build_distribution(player)
-                    break
-                elif choice == '4':
-                    self._cli_action_tweak_upgrade(player)
-                    break
-                elif choice == '5':
-                    self._cli_action_speculate(player)
-                    break
-                elif choice == '6':
-                    print("Spin/Marketing action is not yet implemented.")
-                    # self.game_logic.action_spin_marketing(player, "", "") # Placeholder call
-                    break
-                elif choice == '7':
+                prompt = f"Enter action number (1-{view_idx}): "
+                choice = input(prompt).strip()
+                if choice == str(pass_idx):
                     print(f"{player.name} passes action {action_num}.")
                     self.game_logic.game_state.game_log.append(f"{player.name} passed action {action_num}.")
                     break
-                elif choice == '8':
+                elif choice == str(view_idx):
                     self._display_game_state() # Show full state then re-prompt
                     self._display_player_dashboard(player) # Show player state again
                     print(f"\n{player.name}, choose Action {action_num} of 2 (after viewing state):")
-                    # Re-print action options
-                    print("1. Sink/Source (Build Facility)... 7. Pass, 8. View Full Game State")
+                    for idx, action in enumerate(ACTIONS_DATA, start=1):
+                        desc = action.get("description", "")
+                        if desc:
+                            print(f"{idx}. {action['name']} - {desc}")
+                        else:
+                            print(f"{idx}. {action['name']}")
+                    print(f"{pass_idx}. Pass Action\n{view_idx}. View Full Game State")
                     continue # Re-loop for action choice
+                elif choice.isdigit() and 1 <= int(choice) <= len(ACTIONS_DATA):
+                    action_idx = int(choice) - 1
+                    action_method = ACTIONS_DATA[action_idx]['method']
+                    method_name = f"_cli_{action_method}"
+                    if hasattr(self, method_name):
+                        getattr(self, method_name)(player)
+                    else:
+                        print(f"Action {action_method} not implemented.")
+                    break
                 else:
                     print("Invalid choice. Please try again.")
             except Exception as e:

--- a/water_barons/game_content.toml
+++ b/water_barons/game_content.toml
@@ -1,0 +1,245 @@
+[[facilities]]
+name = "Glacial Tap"
+cost = 5
+base_output = 3
+copies = 3
+description = "Taps into ancient glaciers."
+impact_profile = {GREY = 1, PINK = 1}
+tags = ["ARCTIC", "LIMITED 2"]
+
+[[facilities]]
+name = "Greywater Loop"
+cost = 3
+base_output = 2
+copies = 3
+description = "Recycles wastewater. Reduces Microplastics."
+impact_profile = {GREEN = 1}
+tags = ["RECYCLING"]
+
+[[facilities]]
+name = "Aquifer Well"
+cost = 4
+base_output = 4
+copies = 3
+description = "Standard well drawing from aquifers."
+impact_profile = {BLUE = 2}
+tags = ["GROUNDWATER"]
+
+[[facilities]]
+name = "Desalination Plant"
+cost = 7
+base_output = 5
+copies = 3
+description = "Converts seawater to freshwater."
+impact_profile = {GREY = 2, GREEN = 1}
+tags = ["COASTAL", "HIGH_ENERGY"]
+
+[[facilities]]
+name = "Cloud Harvester"
+cost = 6
+base_output = 2
+copies = 3
+description = "Collects water vapor from the air."
+impact_profile = {GREY = 1}
+tags = ["ATMOSPHERIC"]
+
+[[facilities]]
+name = "Fog Net Array"
+cost = 3
+base_output = 1
+copies = 3
+description = "Passively collects water from fog."
+impact_profile = {}
+tags = ["PASSIVE", "COASTAL"]
+
+[[distributions]]
+name = "Plastic Bottles"
+cost = 1
+copies = 3
+description = "Cheap, adds +1 μP per 2 cubes sold."
+impact_modifier = {"μP_per_cubes_sold" = {impact = "PINK", amount = 1, per_cubes = 2}}
+
+[[distributions]]
+name = "Drone Drops"
+cost = 3
+copies = 3
+description = "Fancy, +1 CO₂e per cube, draws extra Whim next round."
+impact_modifier = {"CO2e_per_cube_sold" = {impact = "GREY", amount = 1, per_cubes = 1}}
+special_effect = "draw_extra_whim_next_round"
+
+[[distributions]]
+name = "Smart-Pipe Network"
+cost = 5
+copies = 3
+description = "Efficient, high upfront cost, low ongoing impact."
+impact_modifier = {}
+
+[[distributions]]
+name = "Aluminum Cans"
+cost = 2
+copies = 3
+description = "Recyclable alternative to plastic, +1 CO₂e per 3 cubes sold (production energy)."
+impact_modifier = {CO2e_per_cubes_sold = {impact = "GREY", amount = 1, per_cubes = 3}}
+
+[[upgrades]]
+name = "Microplastic Filter"
+cost = 4
+copies = 3
+description = "Facility upgrade. Reduces μP per Flow."
+effect_description = "Apply_to_facility: reduce_impact_per_flow(TrackColor.PINK, 1)"
+type = "FACILITY_UPGRADE"
+
+[[upgrades]]
+name = "Bioplastic Seal"
+cost = 3
+copies = 3
+description = "Route upgrade, remove 1 μP after selling with this route."
+effect_description = "Apply_to_route: on_sell_remove_impact(TrackColor.PINK, 1)"
+type = "ROUTE_UPGRADE"
+
+[[upgrades]]
+name = "Algae Carbon Sink"
+cost = 5
+copies = 3
+description = "Facility tag. At Cleanup, move 1 CO₂e cube from track to supply."
+effect_description = "Passive_facility_effect: at_cleanup_reduce_global_impact(TrackColor.GREY, 1)"
+type = "FACILITY_TAG"
+
+[[upgrades]]
+name = "Aquifer Recharge Tech"
+cost = 6
+copies = 3
+description = "R&D Passive. Reduce DEP impact from all your Wells by 1."
+effect_description = "Global_player_passive: reduce_facility_impact_type('Well', TrackColor.BLUE, 1)"
+type = "R&D"
+
+[[upgrades]]
+name = "Eco-Solar Upgrade"
+cost = 4
+copies = 3
+description = "Facility Upgrade. Reduces CO2e impact from target facility by 1."
+effect_description = "Apply_to_facility: reduce_impact_per_flow(TrackColor.GREY, 1)"
+type = "FACILITY_UPGRADE"
+
+[[upgrades]]
+name = "Nano-Resin Cleaners"
+cost = 5
+copies = 3
+description = "Facility Upgrade. Reduces TOX impact from target facility by 1."
+effect_description = "Apply_to_facility: reduce_impact_per_flow(TrackColor.GREEN, 1)"
+type = "FACILITY_UPGRADE"
+
+[[whims]]
+name = "Glitterwave Fashion"
+trigger_condition = "μP < 5"
+pre_round_effect = "DemandSegment:Connoisseurs:current_demand:+2"
+demand_shift = {}
+post_round_fallout = "GlobalImpact:PINK:+2"
+copies = 2
+
+[[whims]]
+name = "Doomscroll Detox"
+trigger_condition = "CO₂e >= 6"
+pre_round_effect = "DemandSegment:Frugalists:current_price:+1"
+demand_shift = {}
+post_round_fallout = "GlobalImpact:GREY:-1"
+copies = 2
+
+[[whims]]
+name = "Heatwave Hysteria"
+trigger_condition = "CO₂e >= 7"
+pre_round_effect = "AllSegments:current_demand:+1"
+demand_shift = {}
+post_round_fallout = "GlobalImpact:GREY:+1"
+copies = 2
+
+[[whims]]
+name = "Sustainable Sipping"
+trigger_condition = "DEP < 4"
+pre_round_effect = "DemandSegment:Eco-Elites:current_price:+1"
+demand_shift = {}
+post_round_fallout = "PlayerEffect:EcoEliteBuyers:GainReputation:1"
+copies = 2
+
+[[global_events]]
+name = "Aquifer Collapse"
+trigger_track = "BLUE"
+trigger_threshold = 8
+effect_description = "All 'Well' type facilities output halved until Depletion <= 6. New Wells cannot be built."
+
+[[global_events]]
+name = "Heatwave Frenzy"
+trigger_track = "GREY"
+trigger_threshold = 9
+effect_description = "Double demand across all segments. All facilities Flow –1 (overheat)."
+
+[[global_events]]
+name = "Microplastic Revelation"
+trigger_track = "PINK"
+trigger_threshold = 8
+effect_description = "All 'Plastic Bottles' routes instantly add +3 μP then flip face-down (cannot be used)."
+
+[[global_events]]
+name = "Mass Recall"
+trigger_track = "GREEN"
+trigger_threshold = 10
+effect_description = "All unsold Water cubes are immediately discarded. No sales this round from tainted supply."
+
+[[global_events]]
+name = "Energy Crisis"
+trigger_track = "GREY"
+trigger_threshold = 7
+effect_description = "Cost of 'Flow' action for energy-heavy facilities (Desal, Drone) increases by 1 CredCoin."
+
+[[global_events]]
+name = "Plastic Blight"
+trigger_track = "PINK"
+trigger_threshold = 6
+effect_description = "Facilities with 'Plastic' in their components or Plastic Bottle routes suffer -1 output/efficiency."
+
+[[global_events]]
+name = "Dustbowl Proclamation"
+trigger_track = "BLUE"
+trigger_threshold = 6
+effect_description = "Cost to build new 'Well' or 'River Diversion' facilities increases by 2 CredCoin."
+
+[[global_events]]
+name = "Toxic Algae Bloom"
+trigger_track = "GREEN"
+trigger_threshold = 7
+effect_description = "Water from 'Coastal' tagged facilities costs +1 CredCoin for players to produce (extra filtering)."
+
+[[actions]]
+name = "Build Facility"
+method = "action_build_facility"
+description = "Construct a facility in an empty slot."
+
+[[actions]]
+name = "Produce Water"
+method = "action_produce_water"
+description = "Activate a facility to produce water (Flow)."
+
+[[actions]]
+name = "Build Distribution"
+method = "action_build_distribution"
+description = "Build a distribution route."
+
+[[actions]]
+name = "Add Upgrade"
+method = "action_tweak_add_upgrade"
+description = "Apply an upgrade to a facility or route."
+
+[[actions]]
+name = "Speculate"
+method = "action_speculate"
+description = "Buy or sell futures tokens."
+
+[[actions]]
+name = "Spin Marketing"
+method = "action_spin_marketing"
+description = "Perform marketing actions."
+
+[[actions]]
+name = "Buy Event Option"
+method = "action_buy_event_option"
+description = "Purchase an option linked to a global event."


### PR DESCRIPTION
## Summary
- move card definitions and player action list to `game_content.toml`
- load card data from TOML in `cards.py`
- use action metadata in the CLI to build the action menu
- allow overriding `game_content.toml` path with `WATER_BARONS_DATA_FILE`
- print action descriptions in the CLI
- test loading card data through environment variable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c22397428832ba3d90347e82fb1e4