### PR TITLE
Fix failing tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,4 +6,5 @@ dependencies = [
     "eventlet>=0.30.0",
     "flask>=3.0.0",
     "flask-socketio>=5.0.0",
+    "pytest>=7.0",
 ]

--- a/tests/test_card_loading.py
+++ b/tests/test_card_loading.py
@@ -3,33 +3,38 @@ import importlib
 import textwrap
 from tempfile import NamedTemporaryFile
 
-import pytest
+from unittest.mock import patch
+import unittest
 
-def test_cards_load_from_env_path(monkeypatch):
-    sample = textwrap.dedent("""
-    [[facilities]]
-    name = "Temp Facility"
-    cost = 1
-    base_output = 1
-    copies = 1
-    impact_profile = {GREY = 1}
 
-    [[actions]]
-    name = "Dummy Action"
-    method = "action_dummy"
-    description = "dummy"
-    """)
-    with NamedTemporaryFile('w+', delete=False) as tmp:
-        tmp.write(sample)
-        tmp_path = tmp.name
-    monkeypatch.setenv('WATER_BARONS_DATA_FILE', tmp_path)
-    import water_barons.cards as cards
-    importlib.reload(cards)
-    try:
-        facilities = cards.get_all_facility_cards()
-        assert any(f.name == "Temp Facility" for f in facilities)
-        assert cards.ACTIONS_DATA and cards.ACTIONS_DATA[0]['name'] == "Dummy Action"
-    finally:
-        monkeypatch.delenv('WATER_BARONS_DATA_FILE', raising=False)
-        os.remove(tmp_path)
+class TestCardLoading(unittest.TestCase):
+    def test_cards_load_from_env_path(self):
+        sample = textwrap.dedent(
+            """
+            [[facilities]]
+            name = "Temp Facility"
+            cost = 1
+            base_output = 1
+            copies = 1
+            impact_profile = {GREY = 1}
+
+            [[actions]]
+            name = "Dummy Action"
+            method = "action_dummy"
+            description = "dummy"
+            """
+        )
+        with NamedTemporaryFile("w+", delete=False) as tmp:
+            tmp.write(sample)
+            tmp_path = tmp.name
+        with patch.dict(os.environ, {"WATER_BARONS_DATA_FILE": tmp_path}):
+            import water_barons.cards as cards
+            importlib.reload(cards)
+            facilities = cards.get_all_facility_cards()
+            self.assertTrue(any(f.name == "Temp Facility" for f in facilities))
+            self.assertTrue(
+                cards.ACTIONS_DATA and cards.ACTIONS_DATA[0]["name"] == "Dummy Action"
+            )
+
         importlib.reload(cards)
+        os.remove(tmp_path)

--- a/tests/test_game_logic.py
+++ b/tests/test_game_logic.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import patch, call
 from water_barons.game_logic import GameLogic
 from water_barons.game_state import GameState
-from water_barons.game_entities import Player, TrackColor, WhimCard
+from water_barons.game_entities import Player, TrackColor, WhimCard, GlobalEventCard
 from water_barons.cards import get_all_whim_cards
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -136,6 +136,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
 name = "itsdangerous"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -195,6 +204,49 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
+]
+
+[[package]]
 name = "python-engineio"
 version = "4.12.2"
 source = { registry = "https://pypi.org/simple" }
@@ -239,6 +291,7 @@ dependencies = [
     { name = "eventlet" },
     { name = "flask" },
     { name = "flask-socketio" },
+    { name = "pytest" },
 ]
 
 [package.metadata]
@@ -246,6 +299,7 @@ requires-dist = [
     { name = "eventlet", specifier = ">=0.30.0" },
     { name = "flask", specifier = ">=3.0.0" },
     { name = "flask-socketio", specifier = ">=5.0.0" },
+    { name = "pytest", specifier = ">=7.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add `pytest` as a dependency
- convert `test_card_loading` to a unittest-based test
- import `GlobalEventCard` for game logic tests
- sync lock file

## Testing
- `uv run -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_686c2972697c832b9c0a799f31d550e7